### PR TITLE
select a config so build completes in new version of kos

### DIFF
--- a/install-DC-toolchain.sh
+++ b/install-DC-toolchain.sh
@@ -146,6 +146,7 @@ checkout_kallistios() {
 
 download_toolchain() {
     msg "Downloading and unpacking toolchain"
+    mv /opt/toolchains/dc/kos/utils/dc-chain/config.mk.stable.sample /opt/toolchains/dc/kos/utils/dc-chain/config.mk
     cd $INSTALL_DIR/kos/utils/dc-chain
     ./download.sh
     ./unpack.sh


### PR DESCRIPTION
In the new versions of KOS you have to select a config file in order to complete the install of sh-elf. This does that for you.